### PR TITLE
add: 게시글 삭제 시 공감/스크랩 내역 삭제, studypost 게시글/댓글 신고 연동

### DIFF
--- a/src/main/java/com/web/stard/controller/StarScrapController.java
+++ b/src/main/java/com/web/stard/controller/StarScrapController.java
@@ -247,5 +247,10 @@ public class StarScrapController {
         return starScrapService.deleteStudyPostStar(id, authentication);
     }
 
+    /* 특정 회원의 공감, 스크랩 내역 전체 삭제(탈퇴 시 사용) */
+    @DeleteMapping("/star/all/{id}")
+    public void deleteAllStarAndStudy(@PathVariable String id) {
+        starScrapService.deleteAllStarAndStudy(id);
+    }
 
 }

--- a/src/main/java/com/web/stard/repository/StarScrapRepository.java
+++ b/src/main/java/com/web/stard/repository/StarScrapRepository.java
@@ -28,4 +28,12 @@ public interface StarScrapRepository extends JpaRepository<StarScrap, Long> {
 
     /* 해당 StudyPost의 공감 전체 조회 */
     List<StarScrap> findAllByStudyPostAndTypeAndTableType(StudyPost studyPost, ActType actType, PostType postType);
+
+    void deleteByMember(Member member);
+
+    void deleteByPostId(Long id);
+
+    void deleteByStudyId(Long id);
+
+    void deleteByStudyPostId(Long id);
 }

--- a/src/main/java/com/web/stard/service/MemberService.java
+++ b/src/main/java/com/web/stard/service/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
     PostRepository postRepository;
     ReplyRepository replyRepository;
     StudyPostRepository studyPostRepository;
-
+    StarScrapRepository starScrapRepository;
 
     public Member find(String id) {
         Optional<Member> result = memberRepository.findById(id);
@@ -149,6 +149,9 @@ public class MemberService {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body("스터디 진행 중에는 탈퇴할 수 없습니다.");
             }
         }
+
+        // 해당 회원의 공감, 스크랩 내역 삭제
+        starScrapRepository.deleteByMember(member);
 
         // recruiter + progressStatus가 null인 것들만 삭제 (진행으로 넘어가지 않은 모집 게시글만 삭제되게)
         List<Study> deleteStudies = studyRepository.findStudiesByRecruiterAndNullProgressStatus(member);

--- a/src/main/java/com/web/stard/service/ReplyService.java
+++ b/src/main/java/com/web/stard/service/ReplyService.java
@@ -98,10 +98,12 @@ public class ReplyService {
         String userId = authentication.getName();
         Member replier = memberService.find(userId);
         StudyPost targetStudyPost = studyPostService.getStudyPost(studyPostId, null);
+        Study targetStudy = studyService.findById(targetStudyPost.getStudy().getId());
 
         Reply reply = Reply.builder()
                 .member(replier)
                 .studyPost(targetStudyPost)
+                .study(targetStudy)
                 .content(replyContent)
                 .type(PostType.STUDYPOST)
                 .build();

--- a/src/main/java/com/web/stard/service/ReportService.java
+++ b/src/main/java/com/web/stard/service/ReportService.java
@@ -32,6 +32,7 @@ public class ReportService {
     private ReplyService replyService;
     private MemberRepository memberRepository;
     private StudyPostRepository studyPostRepository;
+    private StarScrapService starScrapService;
 
     // 해당 글이 이미 신고되었는지 확인
     private Report isTargetPostAlreadyReported(Long targetId, PostType postType) {
@@ -339,6 +340,7 @@ public class ReportService {
             if (replies != null) {
                 replyRepository.deleteAll(replies);
             }
+            starScrapService.deleteByPostId(post.getId());
             postRepository.deleteById(report.getPost().getId());
         }
         else if (report.getTableType() == PostType.REPLY) {
@@ -351,6 +353,7 @@ public class ReportService {
             if (replies != null) {
                 replyRepository.deleteAll(replies);
             }
+            starScrapService.deleteByStudyId(study.getId());
             studyRepository.deleteById(report.getStudy().getId());
         }
         else if (report.getTableType() == PostType.STUDYPOST) {
@@ -360,6 +363,7 @@ public class ReportService {
             if (replies != null) {
                 replyRepository.deleteAll(replies);
             }
+            starScrapService.deleteByStudyPostId(studyPost.getId());
             studyPostRepository.deleteById(report.getStudyPost().getId());
         }
 

--- a/src/main/java/com/web/stard/service/StarScrapService.java
+++ b/src/main/java/com/web/stard/service/StarScrapService.java
@@ -661,4 +661,24 @@ public class StarScrapService {
             return true;
         } return false;
     }
+
+
+    // 특정 회원의 공감, 스크랩 내역 전체 삭제
+    public void deleteAllStarAndStudy(String id) {
+        Member member = memberService.find(id);
+        starScrapRepository.deleteByMember(member);
+    }
+
+    // 게시글 아이디로 공감, 스크랩 내역 삭제하기
+    public void deleteByPostId(Long id) {
+        starScrapRepository.deleteByPostId(id);
+    }
+
+    public void deleteByStudyId(Long id) {
+        starScrapRepository.deleteByStudyId(id);
+    }
+
+    public void deleteByStudyPostId(Long id) {
+        starScrapRepository.deleteByStudyPostId(id);
+    }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 기능 수정

## 반영 브랜치
- feature/admin -> master

## 변경 사항
- 회원 탈퇴 및 강제 탈퇴 시, 해당 회원의 공감, 스크랩 내역 삭제하는 코드 추가
- 신고 승인 시, 해당 게시글 아이디의 공감, 스크랩 내역 삭제하는 코드 추가
- STUDYPOST의 댓글 생성 시, STUDY 정보 저장하도록 수정