### PR TITLE
feat: 비밀번호 재설정 이메일 발급 기능 추가 

### DIFF
--- a/src/main/java/com/web/stard/config/email/EmailController.java
+++ b/src/main/java/com/web/stard/config/email/EmailController.java
@@ -2,36 +2,31 @@ package com.web.stard.config.email;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.mail.SimpleEmail;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/emails")
-public class MailController {
+public class EmailController {
 
-    private final MailService mailService;
+    private final EmailService emailService;
 
     @PostMapping("/verification-requests")
     public ResponseEntity sendMessage(@RequestBody EmailDto emailDto) throws Exception {
-        mailService.sendCodeToEmail(emailDto.getEmail());
+        emailService.sendCodeToEmail(emailDto.getEmail());
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/verifications")
     public Boolean verificationEmail(@RequestParam("email") String email, @RequestParam("authCode") String authCode)  {
         try {
-            return mailService.verifiedCode(email, authCode);
+            return emailService.verifiedCode(email, authCode);
         } catch (Exception e) {
             e.printStackTrace();
             return null;
         }
-
     }
 }

--- a/src/main/java/com/web/stard/config/email/EmailDto.java
+++ b/src/main/java/com/web/stard/config/email/EmailDto.java
@@ -1,10 +1,21 @@
 package com.web.stard.config.email;
 
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
 
 @Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailDto {
 
+    @NotNull
     private String email;
 
+    @Builder
+    public EmailDto(String email) {
+        this.email = email;
+    }
 }

--- a/src/main/java/com/web/stard/config/email/EmailService.java
+++ b/src/main/java/com/web/stard/config/email/EmailService.java
@@ -1,0 +1,12 @@
+package com.web.stard.config.email;
+
+import javax.mail.MessagingException;
+
+public interface EmailService {
+
+    void sendCodeToEmail(String toEmail) throws Exception;
+
+    boolean verifiedCode(String email, String authCode) throws Exception;
+
+    void sendEmailResetPw(EmailDto emailDto) throws MessagingException;
+}

--- a/src/main/java/com/web/stard/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/web/stard/config/jwt/JwtTokenProvider.java
@@ -31,6 +31,8 @@ public class JwtTokenProvider {
     //    private static final long ACCESS_TOKEN_EXPIRE_TIME = 60 * 1000L;              // 유효 기간 Test 용 (1분)
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L;    // 7일
 
+    private static final Long RESET_PW_TOKEN_EXPIRE_TIME = 12 * 60 * 60 * 1000L;
+
     private final Key key;
 
     public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
@@ -67,6 +69,19 @@ public class JwtTokenProvider {
                 .refreshToken(refreshToken)
                 .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
                 .build();
+    }
+
+    public String createToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + RESET_PW_TOKEN_EXPIRE_TIME))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
     }
 
     // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드

--- a/src/main/java/com/web/stard/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/web/stard/config/security/WebSecurityConfig.java
@@ -78,7 +78,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
             // 이메일 인증
             "/emails/verifications",
-            "/emails/verification-requests"
+            "/emails/verification-requests",
+
+            "/find-password",
+            "/reset-password"
     };
 
     @Override

--- a/src/main/java/com/web/stard/controller/PasswordController.java
+++ b/src/main/java/com/web/stard/controller/PasswordController.java
@@ -1,0 +1,36 @@
+package com.web.stard.controller;
+
+import com.web.stard.config.email.EmailDto;
+import com.web.stard.config.email.EmailService;
+import com.web.stard.dto.ResetPasswordResponse;
+import com.web.stard.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.mail.MessagingException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class PasswordController {
+
+    private final EmailService emailService;
+
+    private final MemberService memberService;
+
+    @PostMapping("/find-password")
+    public ResponseEntity<Void> findPassword(@RequestBody EmailDto emailDto) throws MessagingException {
+        emailService.sendEmailResetPw(emailDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ResetPasswordResponse> resetPassword(HttpServletRequest request, @RequestParam("token") String token) throws Exception {
+
+        return ResponseEntity.ok().body(memberService.resetPassword(request, token));
+    }
+
+
+}

--- a/src/main/java/com/web/stard/dto/ResetPasswordResponse.java
+++ b/src/main/java/com/web/stard/dto/ResetPasswordResponse.java
@@ -1,0 +1,24 @@
+package com.web.stard.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResetPasswordResponse {
+
+    private String uri;
+
+    private String email;
+
+    private String accessToken;
+
+    @Builder
+    public ResetPasswordResponse(String uri, String email, String accessToken) {
+        this.uri = uri;
+        this.email = email;
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/web/stard/repository/MemberRepository.java
+++ b/src/main/java/com/web/stard/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package com.web.stard.repository;
 
 import com.web.stard.domain.Member;
-import com.web.stard.domain.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -21,4 +20,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Member findByNickname(String nickname);
 
     List<Member> findByEmailAndPhone(String email, String phone);
+
+    Optional<Member> findByEmail(String email);
+
 }

--- a/src/main/java/com/web/stard/service/MemberService.java
+++ b/src/main/java/com/web/stard/service/MemberService.java
@@ -51,9 +51,6 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private static final String RESET_PW_PREFIX = "ResetPwToken ";
 
-    @Value("${base.front-end.url}")
-    private String baseUrl;
-
     @Transactional
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)

--- a/src/main/java/com/web/stard/service/MemberService.java
+++ b/src/main/java/com/web/stard/service/MemberService.java
@@ -2,11 +2,16 @@ package com.web.stard.service;
 
 import com.web.stard.chat_stomp.ChatMessage;
 import com.web.stard.chat_stomp.ChatMessageRepository;
+import com.web.stard.config.jwt.JwtTokenProvider;
 import com.web.stard.domain.*;
+import com.web.stard.dto.ResetPasswordResponse;
 import com.web.stard.repository.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,6 +19,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
@@ -21,23 +28,37 @@ import java.util.Optional;
 
 @Service
 @Getter @Setter
-@AllArgsConstructor
+@Slf4j
+@RequiredArgsConstructor
 public class MemberService {
 
-    MemberRepository memberRepository;
-    InterestRepository interestRepository;
-    PasswordEncoder passwordEncoder;
-    StudyMemberRepository studyMemberRepository;
-    ProfileRepository profileRepository;
-    StudyRepository studyRepository;
-    ApplicantRepository applicantRepository;
-    AssigneeRepository assigneeRepository;
-    ChatMessageRepository chatMessageRepository;
-    EvaluationRepository evaluationRepository;
-    PostRepository postRepository;
-    ReplyRepository replyRepository;
-    StudyPostRepository studyPostRepository;
-    StarScrapRepository starScrapRepository;
+    private final MemberRepository memberRepository;
+    private final InterestRepository interestRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final StudyMemberRepository studyMemberRepository;
+    private final ProfileRepository profileRepository;
+    private final StudyRepository studyRepository;
+    private final ApplicantRepository applicantRepository;
+    private final AssigneeRepository assigneeRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final EvaluationRepository evaluationRepository;
+    private final PostRepository postRepository;
+    private final ReplyRepository replyRepository;
+    private final StudyPostRepository studyPostRepository;
+    private final StarScrapRepository starScrapRepository;
+
+    private final RedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+    private static final String RESET_PW_PREFIX = "ResetPwToken ";
+
+    @Value("${base.front-end.url}")
+    private String baseUrl;
+
+    @Transactional
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원"));
+    }
 
     public Member find(String id) {
         Optional<Member> result = memberRepository.findById(id);
@@ -246,5 +267,28 @@ public class MemberService {
     // authentication으로 닉네임 찾기
     public Member findNickNameByAuthentication(Authentication authentication) {
         return memberRepository.findNicknameById(authentication.getName());
+    }
+
+    public ResetPasswordResponse resetPassword(HttpServletRequest request, String token) throws Exception {
+        String email = validateResetPwToken(token);
+
+        String accessToken = jwtTokenProvider.createToken(email);
+
+        // TODO 로그 삭제
+        log.info("비밀번호 재설정 반환 uri: " + request.getRequestURI() + "?token=" + token);
+
+        return ResetPasswordResponse.builder()
+                .uri(request.getRequestURI() + "?token=" + token)
+                .email(email)
+                .accessToken(accessToken).build();
+    }
+
+    private String validateResetPwToken(String token) throws Exception {
+        String email = (String)redisTemplate.opsForValue().get(RESET_PW_PREFIX + token);
+
+        if (email == null)
+            throw new Exception();
+
+        return email;
     }
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- feature/reset-password -> main

## 변경 사항
- 비밀번호 찾기 시, 비밀번호 재 설정 이메일 발급 기능 추가

## 테스트 코드

1. 이메일 전송

> POST /find-password

![image](https://github.com/Hanium2023-WeB/starD-backend/assets/106025529/26d27da9-261b-448b-be4c-20837c5701bf)
- ex) http://localhost:8080/reset-password?token=2608a72a-f677-41ad-84ee-cfed14e1def2


2. token 검증 및 ResetPasswordResponse(uri, accessToke, email) 반환

> POST /reset-password?token=1ab04a68-417f-4b59-9fdc-8322fa5affb1



