### PR TITLE
add 수동으로 강제 탈퇴 가능, 탈퇴 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/web/stard/domain/Report.java
+++ b/src/main/java/com/web/stard/domain/Report.java
@@ -17,6 +17,10 @@ public class Report {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "member_id")  // 신고된 회원
+    private Member member;
+
+    @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/web/stard/domain/ReportDetail.java
+++ b/src/main/java/com/web/stard/domain/ReportDetail.java
@@ -20,7 +20,7 @@ public class ReportDetail extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member member;  // 신고한 사람
 
     @Enumerated(EnumType.STRING)
     private ReportReason reason;

--- a/src/main/java/com/web/stard/repository/ReportRepository.java
+++ b/src/main/java/com/web/stard/repository/ReportRepository.java
@@ -3,6 +3,7 @@ package com.web.stard.repository;
 import com.web.stard.domain.Member;
 import com.web.stard.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
     Report findByPostId(Long postId);
@@ -13,4 +14,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     Report findByStudyPostId(Long studyPostId);
 
+    List<Report> findByMember(Member member);
 }

--- a/src/main/java/com/web/stard/repository/StudyRepository.java
+++ b/src/main/java/com/web/stard/repository/StudyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -47,7 +48,7 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
 
     /* 개설자로 progressStatus가 null인 스터디 검색 */
     @Query("SELECT s FROM Study s WHERE s.recruiter = :recruiter AND s.progressStatus IS NULL")
-    List<Study> findStudiesByRecruiterAndNullProgressStatus(Member recruiter);
+    List<Study> findStudiesByRecruiterAndNullProgressStatus(@Param("recruiter") Member recruiter);
     /* 진행 완료된 스터디 (개설자로 검색) */
     List<Study> findByRecruiterAndProgressStatus(Member member, ProgressStatus progressStatus);
 }

--- a/src/main/java/com/web/stard/service/MemberService.java
+++ b/src/main/java/com/web/stard/service/MemberService.java
@@ -149,9 +149,6 @@ public class MemberService {
         // 강제 탈퇴인지 확인
         if (userRole == Role.ADMIN && !id.equals(authentication.getName())) {
             forceDelete = true;
-            if (member.getReportCount() < 1) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("누적 신고 수가 10회 미만이면 강제 탈퇴 처리가 불가능합니다.");
-            }
         }
 
         // 강제 탈퇴 시 비밀번호 확인 및 스터디 진행 여부와 관계 없이 탈퇴 가능

--- a/src/main/java/com/web/stard/service/ReportService.java
+++ b/src/main/java/com/web/stard/service/ReportService.java
@@ -109,6 +109,7 @@ public class ReportService {
         } else {
             // 신고 내역이 없는 경우 - 신고 내역에 추가, 신고자 정보 추가
             Report report = Report.builder()
+                    .member(post.getMember())
                     .post(post)
                     .tableType(post.getType())
                     .build();
@@ -404,6 +405,22 @@ public class ReportService {
 
         for (Member member : members) {
             if (member.getReportCount() >= 10) {
+                // 탈퇴할 회원의 글과 댓글에 대한 Report 가져오기
+                List<Report> deleteReports = reportRepository.findByMember(member);
+
+                // deleteReports에 해당하는 reportDetail 삭제
+                if (deleteReports != null) {
+                    for (Report report : deleteReports) {
+                        List<ReportDetail> reportDetails = reportDetailRepository.findByReportId(report.getId());
+                        if (!reportDetails.isEmpty()) {
+                            reportDetailRepository.deleteAll(reportDetails);
+                        }
+                    }
+
+                    // deleteReports 삭제
+                    reportRepository.deleteAll(deleteReports);
+                }
+
                 // 해당 회원의 공감, 스크랩 내역 삭제
                 starScrapRepository.deleteByMember(member);
 


### PR DESCRIPTION
## PR 타입
- [x] 기능 수정
- [x] 기능 추가

## 반영 브랜치
- feature/admin -> master

## 변경 사항
- mariadb 실행 오류 해결
- 수동으로 강제 탈퇴 가능하게 변경
- 진행x인 스터디 모집글 조회하는 쿼리 메서드에 param 어노테이션 추가
- 탈퇴 시 신고 세부 내역, 신고 내역도 같이 삭제되도록 추가
- Report 엔티티에 member(신고된 사람) 추가